### PR TITLE
Re run clean

### DIFF
--- a/src/renderer/components/results.tsx
+++ b/src/renderer/components/results.tsx
@@ -120,23 +120,25 @@ const renderIndividualResult = (
     <h5 key={suiteResult.name}>{suiteResult.name}</h5>,
     ...suiteResult.results.map(result => {
       const { error, name } = result;
-      const errorTextElement = error ? <pre>{error.toString()}</pre> : null;
-      const retryElem = (
-        <Button
-          icon="outdated"
-          onClick={async function() {
-            await retryTest(name, suiteResult.name, testsDone);
-          }} // using a 'closure'
-          htmltitle="Retry test"
-        ></Button>
-      );
-      const errorElement = error && !slackClosed ? retryElem : errorTextElement;
+      // const errorTextElement = <pre>`error`</pre>;
+      const retryElem = error ? (
+        <div>
+          <Button
+            icon="outdated"
+            onClick={async function() {
+              await retryTest(name, suiteResult.name, testsDone);
+            }} // using a 'closure'
+            htmltitle="Retry test"
+          ></Button>
+        </div>
+      ) : null;
+      const errorElement = error ? (<pre>{error.toString()}</pre>) : null;
       return (
         <div className="result" key={result.name}>
           <p>
             {getIcon(result)} {name}
           </p>
-          {errorTextElement}
+          {retryElem}
           {errorElement}
         </div>
       );

--- a/src/renderer/components/results.tsx
+++ b/src/renderer/components/results.tsx
@@ -155,7 +155,7 @@ export class Results extends React.Component<ResultsProps, {}> {
       });
     }
 
-    /* Retry ONE test */
+    // Retry a test 
     function retryTest(
       testName: string,
       suiteName: string,
@@ -188,12 +188,13 @@ export class Results extends React.Component<ResultsProps, {}> {
         throw new Error(`Could not find ${suiteName}`);
       }
       const results: ItTestParams[] = []; // the list of ItTestParams
+      // Find the right tests
       testNames.forEach(testName => {
         results.push(foundSuiteMethodResults.it.find(
           test => test.name === testName
         ) as ItTestParams);
       });
-      // Find the right test
+      
       return results;
     }
   }

--- a/src/renderer/components/results.tsx
+++ b/src/renderer/components/results.tsx
@@ -136,19 +136,22 @@ export class Results extends React.Component<ResultsProps, {}> {
         throw new Error('undefined suite.');
       }
 
-      let failedTestNames: string[] = getFailedTests(foundSuiteMethodResults, results);
-      
+      let failedTestNames: string[] = getFailedTests(
+        foundSuiteMethodResults,
+        results
+      );
+
       const failedTests: ItTestParams[] = findTests(
         failedTestNames,
         suiteName,
         testsDone
       );
 
-      failedTests.forEach((failedTest) => {
-        runTest(failedTest, (succeeded:boolean) => {
+      failedTests.forEach(failedTest => {
+        runTest(failedTest, (succeeded: boolean) => {
           appendReport(failedTest, succeeded);
           appState.testPassed = succeeded;
-        })
+        });
       });
     }
 

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -24,7 +24,7 @@ export class AppState {
   @observable public done: boolean = false;
 
   // Configuration
-  @observable public closeAppAtEnd: boolean = false;
+  @observable public closeAppAtEnd: boolean = true;
   @observable public generateReportAtEnd: boolean = true;
   @observable public disabledTests: Array<string> = [];
 

--- a/src/smoke/app-window.ts
+++ b/src/smoke/app-window.ts
@@ -108,7 +108,7 @@ export const test: SuiteMethod = async ({ it, beforeAll }) => {
     'can un-minimize the window',
     async () => {
       await minimize(true);
-      await wait(1000);
+      await wait(2000);
 
       assert.ok(!(await getIsHidden(window.client), 'document.hidden'));
     },

--- a/src/utils/get-failed-tests.ts
+++ b/src/utils/get-failed-tests.ts
@@ -1,6 +1,6 @@
 import { TestSuite, Result } from '../interfaces';
 
-// Returns tests that have failed within the test suite. 
+// Returns tests that have failed within the test suite.
 export function getFailedTests(suite: TestSuite, results: Result[]) {
   let testNames: string[] = []; // contains all the test name strings
   // foundSuiteMethodResults


### PR DESCRIPTION
Added a 'retry all' button. 
- the app can already recover from this. 
- the ticker should be unchecked by default
- render a retry button for every case, regardless of whether unticked / ticked 
- add a button next to the testSuite that runs that particular suite. 