### PR TITLE
fix duplicate Running labels

### DIFF
--- a/src/renderer/components/results.tsx
+++ b/src/renderer/components/results.tsx
@@ -105,10 +105,11 @@ export class Results extends React.Component<ResultsProps, {}> {
             intent="warning"
             onClick={() => {
               appState.testRunning = true;
+              appState.whichRunning = name;
               retryTest(name, suiteName, testsDone);
             }} // using a 'closure'
             title="Retry test"
-            text={appState.testRunning ? 'Running...' : `Retry`}
+            text={appState.testRunning && appState.whichRunning === name ? 'Running...' : `Retry`}
           ></Button>
         ) : null;
         const errorElement = error ? <pre>{error.toString()}</pre> : null;

--- a/src/renderer/components/results.tsx
+++ b/src/renderer/components/results.tsx
@@ -101,15 +101,14 @@ export class Results extends React.Component<ResultsProps, {}> {
             className="bp3-button bp3-intent-primary"
             icon="outdated"
             id={name}
-            disabled={appState.testRunning}
+            disabled={appState.testRunning === name ? true : false}
             intent="warning"
             onClick={() => {
-              appState.testRunning = true;
-              appState.whichRunning = name;
+              appState.testRunning = name;
               retryTest(name, suiteName, testsDone);
             }} // using a 'closure'
             title="Retry test"
-            text={appState.testRunning && appState.whichRunning === name ? 'Running...' : `Retry`}
+            text={appState.testRunning === name ? 'Running...' : `Retry`}
           ></Button>
         ) : null;
         const errorElement = error ? <pre>{error.toString()}</pre> : null;

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -51,6 +51,7 @@ export class AppState {
   // Used for button retry info
   @observable public testRunning: boolean = false;
   @observable public testPassed: boolean = false;
+  @observable public whichRunning: string = "";
 
   constructor() {
     this.setup();

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -49,9 +49,8 @@ export class AppState {
   @observable public report: string = '';
 
   // Used for button retry info
-  @observable public testRunning: boolean = false;
+  @observable public testRunning: string | undefined = undefined;
   @observable public testPassed: boolean = false;
-  @observable public whichRunning: string = "";
 
   constructor() {
     this.setup();


### PR DESCRIPTION
I fixed the problem where clicking the 'Run test' button would change the state of _all_ the buttons rather than just that specific one. This fixes #48 but I am not sure if this is the best way to fix this. @felixrieseberg what do you think? Good enough? 