### PR TITLE
add extra wait to avoid failure

### DIFF
--- a/src/smoke/menu-context.ts
+++ b/src/smoke/menu-context.ts
@@ -254,6 +254,7 @@ export const test: SuiteMethod = async ({ it, beforeAll, beforeEach }) => {
     'can "copy link"',
     async () => {
       await switchToChannel(window.client, 'image');
+      await wait(200);
       await openContextMenuForElement(
         window.client,
         'a.p-file_image_thumbnail__wrapper',


### PR DESCRIPTION
The test `can "copy link" ` would randomly fail and I am almost sure it was because the test didn't wait for the element to appear. This fixed it for me. 