### PR TITLE
feat: add DM call test

### DIFF
--- a/src/helpers/send-pointer-event.ts
+++ b/src/helpers/send-pointer-event.ts
@@ -51,8 +51,7 @@ export function sendPointerEvent(
   return client.sendCommand(command, data);
 }
 
-export interface SendClickElementOptions {
-  selector: string;
+export interface SharedSendClickOptions {
   rightClick?: boolean;
   type?: PointerEvents;
   ctrl?: boolean;
@@ -61,12 +60,33 @@ export interface SendClickElementOptions {
   cmd?: boolean;
 }
 
+export interface SendClickForElement extends SharedSendClickOptions {
+  element: WebdriverIOAsync.Element;
+  selector?: undefined;
+}
+export interface SendClickForSelector extends SharedSendClickOptions {
+  element?: undefined;
+  selector: string;
+}
+export type SendClickElementOptions =
+  | SendClickForElement
+  | SendClickForSelector;
+
 export async function sendClickElement(
   client: BrowserObject,
   options: SendClickElementOptions
 ) {
-  const { rightClick, selector, type, alt, cmd, ctrl, shift } = options;
-  const element = await client.$(selector);
+  const {
+    rightClick,
+    element: passedElement,
+    selector,
+    type,
+    alt,
+    cmd,
+    ctrl,
+    shift
+  } = options;
+  const element = passedElement || (await client.$(selector!));
   await element.waitForExist(1000);
   const location = await element.getLocation();
 

--- a/src/smoke/messaging.ts
+++ b/src/smoke/messaging.ts
@@ -112,9 +112,13 @@ export const test: SuiteMethod = async ({ it, beforeAll }) => {
     async () => {
       await switchToChannel(window.client, 'Slackbot');
 
+      const messageElements = await window.client.$$(
+        '[data-qa="message_container"]'
+      );
+
       // Mark a message as unread
       await sendClickElement(window.client, {
-        selector: '[data-qa="message_content"]',
+        element: messageElements[messageElements.length - 1],
         type: PointerEvents.MOUSEDOWNUP,
         alt: true
       });


### PR DESCRIPTION
Introduce a DM call test that rings the other team via shared channels. I added a hack in https://checkpoint.tinyspeck.com/ghe/slack/webapp/pulls/17708 to be able to open multiple 
call windows.